### PR TITLE
Fix error "DropdownSetting is not a type" and update channels

### DIFF
--- a/NixMonitorSettings.qml
+++ b/NixMonitorSettings.qml
@@ -100,16 +100,16 @@ PluginSettings {
         defaultValue: true
     }
 
-    DropdownSetting {
+    SelectionSetting {
         settingKey: "nixpkgsChannel"
         label: "NixOS Channel"
         description: "Which channel to check for updates"
         defaultValue: "nixos-unstable"
         options: [
             { value: "nixos-unstable", label: "nixos-unstable" },
-            { value: "nixos-24.11", label: "nixos-24.11" },
-            { value: "nixos-24.05", label: "nixos-24.05" },
-            { value: "nixos-23.11", label: "nixos-23.11" }
+            { value: "nixos-25.11", label: "nixos-25.11" },
+            { value: "nixos-25.05", label: "nixos-25.05" },
+            { value: "nixos-24.11", label: "nixos-24.11" }
         ]
     }
 


### PR DESCRIPTION
I use nixos25.11 and install plugin through dms plugin register.  When I activate this plugin I cannot configure it's setting through dms settings and i got error " WARN scene: file:///home/user/.config/DankMaterialShell/plugins/nixMonitor/NixMonitorSettings.qml[103:5]: DropdownSetting is not a type". I read documentation and made fix.  It my first pull request, so I am sorry if i did something wrong.